### PR TITLE
bugfix: bloom from GetByName not init client

### DIFF
--- a/bloom.go
+++ b/bloom.go
@@ -158,6 +158,7 @@ func GetByName(client *redis.Client, name string) (bloom *Bloom, err error) {
 	}
 
 	bloom = &Bloom{
+		client:client,
 		name:  name,
 		n:     n,
 		p:     p,


### PR DESCRIPTION
```
log: bf duplicated
log: bloom from GetByName
log: bl = &{client:<nil> name:bf n:400000000 p:0.001 m:5751035027 k:10 parts:[0xc0000a8420 0xc0000a84e0]}

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x1208bb0]

goroutine 1 [running]:
github.com/go-redis/redis.(*Client).Pipeline(0x0, 0xc0000d7e85, 0xb)
	/Users/uz/r/work/workspaces/go/pkg/mod/github.com/go-redis/redis@v6.15.2+incompatible/redis.go:461 +0x40
dycrawler/bloomf.(*Bloom).Exists(0xc0000ac320, 0xc0000d7e85, 0xb, 0xb, 0xc0000d7f58, 0x3, 0x3)
	/Users/uz/r/work/workspaces/go/src/a/a/bloomf/bloomf.go:182 +0x7b
main.main()
	/Users/uz/r/work/workspaces/go/src/a/a/test.go:40 +0x340
```